### PR TITLE
Opam constraints

### DIFF
--- a/oraft.opam
+++ b/oraft.opam
@@ -14,6 +14,16 @@ build: [ "dune" "build" "-j" jobs "-p" name "@install" ]
 depends: [
   "dune" {build & >= "1.3.0"}
   "batteries" {>= "2.8.0"}
+  "base64" {< "3.0.0"}
+  "cmdliner"
+  "extprot"
+  "fmt"
+  "logs"
+  "lwt"
+  "lwt_ppx"
+  "tls"
+  "x509"
+  "extprot"
 ]
 synopsis: "Implementation of Raft consensus algorithm"
 description: """


### PR DESCRIPTION
The current constraints do not encapsulate all the actual libraries used by the oraft package.

This PR adds the majority of those constraints. Currently only the `oraft.opam` file has been updated.